### PR TITLE
fix: enable `set positional-arguments` in justfile (#1169)

### DIFF
--- a/codex-rs/justfile
+++ b/codex-rs/justfile
@@ -1,18 +1,20 @@
+set positional-arguments
+
 # Display help
 help:
     just -l
 
 # `codex`
 codex *args:
-    cargo run --bin codex -- {{args}}
+    cargo run --bin codex -- "$@"
 
 # `codex exec`
 exec *args:
-    cargo run --bin codex -- exec {{args}}
+    cargo run --bin codex -- exec "$@"
 
 # `codex tui`
 tui *args:
-    cargo run --bin codex -- tui {{args}}
+    cargo run --bin codex -- tui "$@"
 
 # format code
 fmt:


### PR DESCRIPTION
The way these definitions worked before, they did not handle quoted args with spaces properly.

For example, if you had `/tmp/test-just/printlen.py` as:

```python
#!/usr/bin/env python3

import sys

print(len(sys.argv))
```

and your `justfile` was:

```
printlen *args:
    /tmp/test-just/printlen.py {{args}}
```

Then:

```shell
$ just printlen foo bar
3
$ just printlen 'foo bar'
3
```

which is not what we want: `'foo bar'` should be treated as one argument.

The fix is to use
[positional-arguments](https://github.com/casey/just/blob/515e806b5121a4696113ef15b5f0b12e69854570/README.md#L1131):

```
set positional-arguments

printlen *args:
    /tmp/test-just/printlen.py "$@"
```