### PR TITLE
chore: fix Rust release process so generated .tar.gz source works wit…

### DIFF
--- a/codex-rs/scripts/create_github_release.sh
+++ b/codex-rs/scripts/create_github_release.sh
@@ -28,10 +28,19 @@ else
   VERSION=$(printf '0.0.%d' "$(date +%y%m%d%H%M)")
 fi
 TAG="rust-v$VERSION"
+RELEASE_BRANCH="release/$TAG"
+
 git checkout -b "$TAG"
 perl -i -pe "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
 git add Cargo.toml
 git commit -m "Release $VERSION"
 git tag -a "$TAG" -m "Release $VERSION"
+
+# The commit identified by the tag must be reachable from a branch so that
+# when GitHub creates the `Source code (tar.gz)` for the release, it can find
+# the commit. This is a requirement for Homebrew to be able to install the
+# package from the tarball.
+git push origin "$RELEASE_BRANCH"
 git push origin "refs/tags/$TAG"
+
 git checkout "$CURRENT_BRANCH"


### PR DESCRIPTION
…h Homebrew (#1423)

Looking at existing releases such as
https://github.com/openai/codex/releases/tag/codex-rs-b289c9207090b2e27494545d7b5404e063bd86f3-1-rust-v0.1.0-alpha.4, the `.tar.gz` for the source code still seems to have `0.0.0` as the `version` in `codex-rs/Cargo.toml` instead of what the tag seems to say it should have:


https://github.com/openai/codex/blob/b289c9207090b2e27494545d7b5404e063bd86f3/codex-rs/Cargo.toml#L21

ChatGPT claims:

> When GitHub generates the Source code (tar.gz) archive for a tag:
	•	It uses the commit the tag points to.
• But in some cases (e.g., shallow clones, GitHub CI, or local tools that only clone the default branch), that commit may not be included, and you might get an outdated view or nothing at all depending on how it’s fetched.
	
Trying this recommended fix.