### PR TITLE
Implement redraw debounce (#1599)

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -8,6 +8,10 @@ use crate::slash_command::SlashCommand;
 pub(crate) enum AppEvent {
     CodexEvent(Event),
 
+    /// Request a redraw which will be debounced by the [`App`].
+    RequestRedraw,
+
+    /// Actually draw the next frame.
     Redraw,
 
     KeyEvent(KeyEvent),

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -212,7 +212,7 @@ impl BottomPane<'_> {
     }
 
     pub(crate) fn request_redraw(&self) {
-        self.app_event_tx.send(AppEvent::Redraw)
+        self.app_event_tx.send(AppEvent::RequestRedraw)
     }
 
     /// Returns true when a popup inside the composer is visible.

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -431,7 +431,7 @@ impl ChatWidget<'_> {
     }
 
     fn request_redraw(&mut self) {
-        self.app_event_tx.send(AppEvent::Redraw);
+        self.app_event_tx.send(AppEvent::RequestRedraw);
     }
 
     pub(crate) fn add_diff_output(&mut self, diff_output: String) {

--- a/codex-rs/tui/src/status_indicator_widget.rs
+++ b/codex-rs/tui/src/status_indicator_widget.rs
@@ -65,7 +65,7 @@ impl StatusIndicatorWidget {
                     std::thread::sleep(Duration::from_millis(200));
                     counter = counter.wrapping_add(1);
                     frame_idx_clone.store(counter, Ordering::Relaxed);
-                    app_event_tx_clone.send(AppEvent::Redraw);
+                    app_event_tx_clone.send(AppEvent::RequestRedraw);
                 }
             });
         }


### PR DESCRIPTION
## Summary
- debouce redraw events so repeated requests don't overwhelm the terminal
- add `RequestRedraw` event and schedule redraws after 100ms

## Testing
- `cargo clippy --tests`
- `cargo test` *(fails: Sandbox Denied errors in landlock tests)*

------
https://chatgpt.com/codex/tasks/task_i_68792a65b8b483218ec90a8f68746cd8

---------